### PR TITLE
Upgrade org.jetbrains.intellij from 0.4.9 to 0.4.18

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -5,15 +5,14 @@
 ## Please, don't put extra comments in that file yet, keeping them is not supported yet.
 
 plugin.io.gitlab.arturbosch.detekt=1.7.3
-##                     # available=1.7.4
+##                     # available=1.8.0
 
 plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 
 plugin.org.jetbrains.dokka=0.9.18
 ##             # available=0.10.1
 
-plugin.org.jetbrains.intellij=0.4.9
-##                # available=0.4.18
+plugin.org.jetbrains.intellij=0.4.18
 
 plugin.org.jlleitschuh.gradle.ktlint=8.2.0
 ##                       # available=9.2.1
@@ -21,3 +20,4 @@ plugin.org.jlleitschuh.gradle.ktlint=8.2.0
 version.io.github.classgraph..classgraph=4.8.47
 
 version.kotlin=1.3.71
+## # available=1.3.72


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.