### PR TITLE
Upgrade org.jetbrains.dokka from 0.9.18 to 0.10.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -9,8 +9,7 @@ plugin.io.gitlab.arturbosch.detekt=1.7.3
 
 plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 
-plugin.org.jetbrains.dokka=0.9.18
-##             # available=0.10.1
+plugin.org.jetbrains.dokka=0.10.1
 
 plugin.org.jetbrains.intellij=0.4.9
 ##                # available=0.4.18


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.