### PR TITLE
Upgrade org.jetbrains.intellij from 0.4.9 to 0.4.18

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -12,8 +12,7 @@ plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 plugin.org.jetbrains.dokka=0.9.18
 ##             # available=0.10.1
 
-plugin.org.jetbrains.intellij=0.4.9
-##                # available=0.4.18
+plugin.org.jetbrains.intellij=0.4.18
 
 plugin.org.jlleitschuh.gradle.ktlint=9.2.1
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.