### PR TITLE
Upgrade kotlin from 1.3.72 to 1.4.0-rc

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -16,4 +16,4 @@ plugin.org.jlleitschuh.gradle.ktlint=9.3.0
 
 version.io.github.classgraph..classgraph=4.8.47
 
-version.kotlin=1.3.72
+version.kotlin=1.4.0-rc


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.