### PR TITLE
Upgrade dokka from 0.10.1 to 1.4.0-rc

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -8,7 +8,7 @@ plugin.io.gitlab.arturbosch.detekt=1.12.0
 
 plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 
-plugin.org.jetbrains.dokka=0.10.1
+plugin.org.jetbrains.dokka=1.4.0-rc
 
 plugin.org.jetbrains.intellij=0.4.21
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.