### PR TITLE
Upgrade intellij from 0.4.21 to 0.4.26

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -10,7 +10,7 @@ plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 
 plugin.org.jetbrains.dokka=0.10.1
 
-plugin.org.jetbrains.intellij=0.4.21
+plugin.org.jetbrains.intellij=0.4.26
 
 plugin.org.jlleitschuh.gradle.ktlint=9.3.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.