### PR TITLE
Upgrade kotlin from 1.4.20 to 1.4.21

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -16,4 +16,4 @@ plugin.org.jlleitschuh.gradle.ktlint=9.4.1
 
 version.io.github.classgraph..classgraph=4.8.47
 
-version.kotlin=1.4.20
+version.kotlin=1.4.21


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.