### PR TITLE
Upgrade git-sensitive-semantic-versioning from 0.2.2 to 0.2.3

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -6,7 +6,7 @@
 
 plugin.io.gitlab.arturbosch.detekt=1.15.0
 
-plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
+plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.3
 
 plugin.org.jetbrains.dokka=1.4.20
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.