### PR TITLE
Upgrade kotlin from 1.4.21 to 1.4.30

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -16,4 +16,4 @@ plugin.org.jlleitschuh.gradle.ktlint=10.0.0
 
 version.io.github.classgraph..classgraph=4.8.47
 
-version.kotlin=1.4.21
+version.kotlin=1.4.30


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.