### PR TITLE
Upgrade kotlin from 1.4.31 to 1.4.32

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -16,4 +16,4 @@ plugin.org.jlleitschuh.gradle.ktlint=10.0.0
 
 version.io.github.classgraph..classgraph=4.8.103
 
-version.kotlin=1.4.31
+version.kotlin=1.4.32


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.