### PR TITLE
Upgrade kotlin from 1.4.32 to 1.5.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -16,4 +16,4 @@ plugin.org.jlleitschuh.gradle.ktlint=10.0.0
 
 version.io.github.classgraph..classgraph=4.8.104
 
-version.kotlin=1.4.32
+version.kotlin=1.5.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.