### PR TITLE
Upgrade dokka from 1.4.32 to 1.5.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -8,7 +8,7 @@ plugin.io.gitlab.arturbosch.detekt=1.17.1
 
 plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.3
 
-plugin.org.jetbrains.dokka=1.4.32
+plugin.org.jetbrains.dokka=1.5.0
 
 plugin.org.jetbrains.intellij=0.7.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.